### PR TITLE
Update phaser version documentation link

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { Preloader } from './scenes/Preloader';
 import { Game, Types } from "phaser";
 
 //  Find out more information about the Game Config at:
-//  https://newdocs.phaser.io/docs/3.70.0/Phaser.Types.Core.GameConfig
+//  https://newdocs.phaser.io/docs/3.86.0/Phaser.Types.Core.GameConfig
 const config: Types.Core.GameConfig = {
     type: Phaser.AUTO,
     width: 1024,


### PR DESCRIPTION
Since the package.json refs to the latest 3.86.0 version, I thought the main.ts link to the documentation should reflect that 😋